### PR TITLE
GLA-761 Avoid DBUS panic when removing last 'name' being tracked

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -319,8 +319,11 @@ func (conn *Conn) inWorker() {
 						conn.namesLck.Lock()
 						for i, v := range conn.names {
 							if v == name {
-								conn.names = append(conn.names[:i],
-									conn.names[i+1:]...)
+								if len(conn.names) == 1 {
+									conn.names = conn.names[:0]
+								} else {
+									conn.names = append(conn.names[:i], conn.names[i+1:]...)
+								}
 							}
 						}
 						conn.namesLck.Unlock()


### PR DESCRIPTION
The DBUS code is used when an OVAL systemdunitproperty object attempts to collect info on a unit AND we are not running in the remote_helper. In addition, when trying to collect info on a non-existing unit, an additional attempt will be made to get information. This can lead to a case where we get notified to remove the last ‘name’ that we are tracking. The existing code gets an an array out of bounds panic when this happens.

I'll merge this to master (and give it a new tag) since I think that is the only way to get it into an agent build...